### PR TITLE
feat: multi auto-complete

### DIFF
--- a/packages/auto-complete-element/CHANGELOG.md
+++ b/packages/auto-complete-element/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for multiple selections
 - Add `data-empty` attribute when there is zero search results
+- Add `debounce` on input filter
 
 ### Added
 - Add multi select support

--- a/packages/auto-complete-element/CHANGELOG.md
+++ b/packages/auto-complete-element/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Add support for multiple selections
+- Add `data-empty` attribute when there is zero search results
+
+### Added
 - Add multi select support
 
 ## [0.1.0] - 2022-05-29

--- a/packages/auto-complete-element/CHANGELOG.md
+++ b/packages/auto-complete-element/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Add multi select support
+
 ## [0.1.0] - 2022-05-29
 
 ### Added

--- a/packages/auto-complete-element/CHANGELOG.md
+++ b/packages/auto-complete-element/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Add support for multiple selections
-- Add `data-empty` attribute when search results is empty
-- Add `debounce` on input filter
+- Add support for multiple selections #10
+- Add `data-empty` attribute when search results is empty #10
+- Add `debounce` on input filter #10
 
 ## [0.1.1] - 2022-05-30
 

--- a/packages/auto-complete-element/CHANGELOG.md
+++ b/packages/auto-complete-element/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `data-empty` attribute when there is zero search results
 - Add `debounce` on input filter
 
-### Added
-- Add multi select support
-
 ## [0.1.0] - 2022-05-29
 
 ### Added

--- a/packages/auto-complete-element/README.md
+++ b/packages/auto-complete-element/README.md
@@ -77,6 +77,37 @@ the blankslate like this:
 }
 ```
 
+### Selections via `aria-selected="true"` attribute
+
+`aria-selected="true"` is set on the selected option which can be used to differentiate the selected elements from
+the non-selected elements visually via CSS.
+
+```html
+<auto-complete for="list">
+  <input type="text">
+  <ul id="list">
+    <li role="option" aria-selected="true">
+      Option 1
+      <span>(selected)</span>
+    </li>
+    <li role="option">
+      Option 2
+      <span>(selected)</span>
+    </li>
+  </ul>
+</auto-complete>
+```
+
+```css
+li[role="option"] > span {
+  display: none;
+}
+
+li[role="option"][aria-selected="true"] > span {
+  display: inline-block;
+}
+```
+
 ### Events
 `auto-complete:selected` is fired after an option is selected. You can find which option was selected
 by:

--- a/packages/auto-complete-element/README.md
+++ b/packages/auto-complete-element/README.md
@@ -27,10 +27,54 @@ import '@dahli/auto-complete-element'
 </auto-complete>
 ```
 
+#### Multiple selections
+
+You can set the `multiple` attribute on the `<auto-complete>` to allow selections on multiple options.
+
+```html
+<auto-complete for="list" multiple>
+  <input type="text">
+  <ul id="list">
+    <li role="option">Option 1</li>
+    <li role="option">Option 2</li>
+    <li role="option">Option 3</li>
+  </ul>
+</auto-complete>
+```
+
+### Filtering options
+
+The default filtering logic is substring.
+
 The `data-autocomplete-value` can be used to customize the search term.
 
 ```html
-<li role="option" data-autocomplete-value="another option">Option<li>
+<li role="option" data-autocomplete-value="Battlestar">Option<li>
+```
+
+#### Blankslate
+
+`data-empty` attribute is added to the list container when search results is empty. You can use CSS to show/hide
+the blankslate like this:
+
+```html
+<auto-complete for="list">
+  <input type="text">
+  <ul id="list" class="container">
+    <li role="option">Option 1</li>
+    <li class="blankslate">No results found!</li>
+  </ul>
+</auto-complete>
+```
+
+```css
+.blankslate {
+  display: none;
+}
+
+.container[data-empty] .blankslate {
+  display: block;
+}
 ```
 
 ### Events
@@ -45,9 +89,6 @@ autocomplete.addEventListener('auto-complete:selected', (event) => {
   console.log(option);
 });
 ```
-
-### Todo
-- [ ] Support multi-select
 
 ## License
 Distributed under the MIT license.

--- a/packages/auto-complete-element/examples/index.html
+++ b/packages/auto-complete-element/examples/index.html
@@ -35,11 +35,17 @@
       li[data-tracking] {
         background-color: gray;
       }
+
+      input {
+        display: block;
+        width: 100%;
+      }
     </style>
   </head>
 
   <body class="container-sm py-6">
-    <auto-complete for="options">
+    <h3>Multi select</h3>
+    <auto-complete for="options" multiple style="display: block;">
       <input type="text" class="form-control">
 
       <ul id="options">
@@ -93,6 +99,27 @@
         </li>
       </ul>
     </auto-complete>
+
+    <h3 style="margin-top: 40px;">Single select</h3>
+    <auto-complete for="users" style="display: block;">
+      <input type="text" class="form-control">
+
+      <ul id="users">
+        <li role="option" data-autocomplete-value="Tim">
+          Tim
+          <span>(checked)</span>
+        </li>
+        <li role="option" data-autocomplete-value="Mike">
+          Mike
+          <span>(checked)</span>
+        </li>
+        <li role="option" data-autocomplete-value="Kene">
+          Kene
+          <span>(checked)</span>
+        </li>
+      </ul>
+    </auto-complete>
+
     <script src="../dist/index.js"></script>
   </body>
 </html>

--- a/packages/auto-complete-element/spec/combobox.spec.ts
+++ b/packages/auto-complete-element/spec/combobox.spec.ts
@@ -51,6 +51,7 @@ describe('Combobox', () => {
       expect(input).to.have.attribute('aria-controls', list.id);
       expect(input).to.have.attribute('aria-autocomplete', 'list');
       expect(list).to.have.attribute('role', 'listbox');
+      expect(list).not.to.have.attribute('aria-multiselectable');
     });
 
     it('on starting combobox', () => {
@@ -265,6 +266,52 @@ describe('Combobox', () => {
 
       mouseover(options[2]);
       expectInputLinkedWithOption(input, options[2]);
+    });
+  });
+
+  describe('multiple selections', () => {
+    let el: HTMLElement;
+    let input: HTMLInputElement;
+    let list: HTMLElement;
+    let options: NodeListOf<HTMLElement>;
+    let combobox: Combobox;
+
+    beforeEach(async () => {
+      el = await fixture(html`
+        <div>
+          <input type="text" />
+          <ul>
+            <li role="option">Player</li>
+            <li role="option">Taxi</li>
+          </ul>
+        </div>
+      `);
+
+      input = el.querySelector('input');
+      list = el.querySelector('ul');
+      options = list.querySelectorAll<HTMLElement>('[role="option"]');
+      combobox = new Combobox(input, list, { isMultiple: true });
+    });
+
+    afterEach(() => {
+      combobox.stop();
+    });
+
+    it('adds aria-multiselectable', () => {
+      expect(list).to.have.attribute('aria-multiselectable', 'true');
+    });
+
+    it('selecting options', () => {
+      combobox.start();
+
+      expect(options[0]).to.have.attribute('aria-selected', 'false');
+      expect(options[1]).to.have.attribute('aria-selected', 'false');
+
+      options[0].click();
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+
+      options[1].click();
+      expect(options[1]).to.have.attribute('aria-selected', 'true');
     });
   });
 });

--- a/packages/auto-complete-element/spec/index.spec.ts
+++ b/packages/auto-complete-element/spec/index.spec.ts
@@ -206,4 +206,35 @@ describe('AutoCompleteElement', () => {
       expect(relatedTarget).to.equal(options[1]);
     });
   });
+
+  describe('multiple selections', () => {
+    let el: AutoCompleteElement;
+    let input: HTMLInputElement;
+    let list: HTMLElement;
+    let options: NodeListOf<HTMLElement>;
+
+    beforeEach(async () => {
+      el = await fixture(html`
+        <auto-complete for="list" multiple>
+          <input type="text" />
+          <ul id="list">
+            <li role="option">Player</li>
+            <li role="option" data-autocomplete-value="Orange">Taxi</li>
+          </ul>
+        </auto-complete>
+      `);
+
+      input = el.querySelector('input');
+      list = el.querySelector('ul');
+      options = list.querySelectorAll('[role="option"]');
+    });
+
+    it('does not close the list and does not update the input value', () => {
+      input.focus();
+
+      options[0].dispatchEvent(new CustomEvent('combobox:commit', { bubbles: true }));
+      expect(input.value).to.equal(''); // does not update the input value
+      expect(list).not.to.have.attribute('hidden'); // does not hide the input
+    });
+  });
 });

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -1,6 +1,7 @@
 import type AutoCompleteElement from './index';
 import Combobox from './combobox';
 import useOutsideInteraction from '@dahli/utils/src/use-outside-interaction';
+import { debounce } from '@dahli/utils/src/delay';
 
 export default class Autocomplete {
   element: AutoCompleteElement;
@@ -25,7 +26,7 @@ export default class Autocomplete {
     this.onFocus = this.onFocus.bind(this);
     this.onKeydown = this.onKeydown.bind(this);
     this.onCommit = this.onCommit.bind(this);
-    this.onInput = this.onInput.bind(this);
+    this.onInput = debounce(this.onInput.bind(this), 300);
 
     this.input.addEventListener('focus', this.onFocus);
     this.input.addEventListener('keydown', this.onKeydown);

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -101,6 +101,7 @@ export default class Autocomplete {
     const query = this.input.value.trim();
     this.combobox.options.forEach(filterOptions(query, { matching: 'data-autocomplete-value' }));
     this.combobox.setActive(this.combobox.visibleOptions[0]);
+    this.list.toggleAttribute('data-empty', this.combobox.visibleOptions.length === 0);
   }
 
   onCommit(event: Event) {

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -4,6 +4,7 @@ import useOutsideInteraction from '@dahli/utils/src/use-outside-interaction';
 import { debounce } from '@dahli/utils/src/delay';
 
 const AUTOCOMPLETE_VALUE_ATTR = 'data-autocomplete-value';
+const DATA_EMPTY_ATTR = 'data-empty';
 
 export default class Autocomplete {
   element: AutoCompleteElement;
@@ -52,7 +53,7 @@ export default class Autocomplete {
   onListToggle() {
     if (this.list.hidden) {
       this.combobox.stop();
-      this.list.removeAttribute('data-empty');
+      this.list.removeAttribute(DATA_EMPTY_ATTR);
       syncSelection(this);
     } else {
       this.combobox.start();
@@ -105,7 +106,7 @@ export default class Autocomplete {
     const query = this.input.value.trim();
     this.combobox.options.forEach(filterOptions(query, { matching: AUTOCOMPLETE_VALUE_ATTR }));
     this.combobox.setActive(this.combobox.visibleOptions[0]);
-    this.list.toggleAttribute('data-empty', this.combobox.visibleOptions.length === 0);
+    this.list.toggleAttribute(DATA_EMPTY_ATTR, this.combobox.visibleOptions.length === 0);
   }
 
   onCommit(event: Event) {

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -52,6 +52,7 @@ export default class Autocomplete {
   onListToggle() {
     if (this.list.hidden) {
       this.combobox.stop();
+      this.list.removeAttribute('data-empty');
       syncSelection(this);
     } else {
       this.combobox.start();
@@ -154,13 +155,12 @@ function filterOptions(query: string, { matching }: { matching: string }) {
 
 function syncSelection(autocomplete: Autocomplete) {
   const { combobox, input, isMultiple } = autocomplete;
-  if (isMultiple) {
+  const selectedOption = combobox.options.filter(selected)[0];
+
+  if (isMultiple || !selectedOption) {
     input.value = '';
   } else {
-    const selectedOption = combobox.options.filter(selected)[0];
-    if (selectedOption) {
-      input.value = (selectedOption.getAttribute(AUTOCOMPLETE_VALUE_ATTR) || selectedOption.textContent) as string;
-    }
+    input.value = (selectedOption.getAttribute(AUTOCOMPLETE_VALUE_ATTR) || selectedOption.textContent) as string;
   }
 }
 

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -6,6 +6,7 @@ export default class Autocomplete {
   element: AutoCompleteElement;
   input: HTMLInputElement;
   list: HTMLElement;
+  isMultiple: boolean;
   combobox: Combobox;
   listObserver: MutationObserver;
 
@@ -15,7 +16,8 @@ export default class Autocomplete {
     this.list = list;
 
     this.list.hidden = true;
-    this.combobox = new Combobox(this.input, this.list);
+    this.isMultiple = this.element.hasAttribute('multiple');
+    this.combobox = new Combobox(this.input, this.list, { isMultiple: this.isMultiple });
 
     this.input.setAttribute('spellcheck', 'false');
     this.input.setAttribute('autocomplete', 'off');
@@ -106,8 +108,10 @@ export default class Autocomplete {
     if (!(option instanceof HTMLElement)) return;
 
     const value = (option.getAttribute('data-autocomplete-value') || option.textContent) as string;
-    this.input.value = value;
-    this.list.hidden = true;
+    if (!this.isMultiple) {
+      this.input.value = value;
+      this.list.hidden = true;
+    }
 
     this.list.dispatchEvent(
       new CustomEvent('auto-complete:selected', {
@@ -145,10 +149,14 @@ function filterOptions(query: string, { matching }: { matching: string }) {
 }
 
 function syncSelection(autocomplete: Autocomplete) {
-  const { combobox, input } = autocomplete;
-  const selectedOption = combobox.options.filter(selected)[0];
-  if (selectedOption) {
-    input.value = (selectedOption.getAttribute('data-autocomplete-value') || selectedOption.textContent) as string;
+  const { combobox, input, isMultiple } = autocomplete;
+  if (isMultiple) {
+    input.value = '';
+  } else {
+    const selectedOption = combobox.options.filter(selected)[0];
+    if (selectedOption) {
+      input.value = (selectedOption.getAttribute('data-autocomplete-value') || selectedOption.textContent) as string;
+    }
   }
 }
 

--- a/packages/auto-complete-element/src/autocomplete.ts
+++ b/packages/auto-complete-element/src/autocomplete.ts
@@ -3,6 +3,8 @@ import Combobox from './combobox';
 import useOutsideInteraction from '@dahli/utils/src/use-outside-interaction';
 import { debounce } from '@dahli/utils/src/delay';
 
+const AUTOCOMPLETE_VALUE_ATTR = 'data-autocomplete-value';
+
 export default class Autocomplete {
   element: AutoCompleteElement;
   input: HTMLInputElement;
@@ -60,7 +62,7 @@ export default class Autocomplete {
     if (!this.list.hidden) return;
 
     this.list.hidden = false;
-    this.combobox.options.forEach(filterOptions('', { matching: 'data-autocomplete-value' }));
+    this.combobox.options.forEach(filterOptions('', { matching: AUTOCOMPLETE_VALUE_ATTR }));
     activateFirstOption(this);
   }
 
@@ -76,7 +78,7 @@ export default class Autocomplete {
       case 'ArrowDown':
         if (event.altKey && this.list.hidden) {
           this.list.hidden = false;
-          this.combobox.options.forEach(filterOptions('', { matching: 'data-autocomplete-value' }));
+          this.combobox.options.forEach(filterOptions('', { matching: AUTOCOMPLETE_VALUE_ATTR }));
           activateFirstOption(this);
           event.preventDefault();
           event.stopPropagation();
@@ -100,7 +102,7 @@ export default class Autocomplete {
     }
 
     const query = this.input.value.trim();
-    this.combobox.options.forEach(filterOptions(query, { matching: 'data-autocomplete-value' }));
+    this.combobox.options.forEach(filterOptions(query, { matching: AUTOCOMPLETE_VALUE_ATTR }));
     this.combobox.setActive(this.combobox.visibleOptions[0]);
     this.list.toggleAttribute('data-empty', this.combobox.visibleOptions.length === 0);
   }
@@ -109,7 +111,7 @@ export default class Autocomplete {
     const option = event.target;
     if (!(option instanceof HTMLElement)) return;
 
-    const value = (option.getAttribute('data-autocomplete-value') || option.textContent) as string;
+    const value = (option.getAttribute(AUTOCOMPLETE_VALUE_ATTR) || option.textContent) as string;
     if (!this.isMultiple) {
       this.input.value = value;
       this.list.hidden = true;
@@ -157,7 +159,7 @@ function syncSelection(autocomplete: Autocomplete) {
   } else {
     const selectedOption = combobox.options.filter(selected)[0];
     if (selectedOption) {
-      input.value = (selectedOption.getAttribute('data-autocomplete-value') || selectedOption.textContent) as string;
+      input.value = (selectedOption.getAttribute(AUTOCOMPLETE_VALUE_ATTR) || selectedOption.textContent) as string;
     }
   }
 }

--- a/packages/auto-complete-element/src/combobox.ts
+++ b/packages/auto-complete-element/src/combobox.ts
@@ -81,12 +81,8 @@ export default class Combobox {
   }
 
   onClick(event: Event) {
-    const { target } = event;
-    if (!(target instanceof HTMLElement)) return;
-
-    const option = target.closest<HTMLElement>('[role="option"]');
-    if (!(option instanceof HTMLElement)) return;
-    if (!enabled(option)) return;
+    const option = getClosestOptionFrom(event.target);
+    if (!option || !enabled(option)) return;
 
     this.selectOption(option);
     option.dispatchEvent(new CustomEvent('combobox:commit', { bubbles: true }));
@@ -98,7 +94,7 @@ export default class Combobox {
       return;
     }
 
-    const option = getClosestOptionFrom(event.target as HTMLElement);
+    const option = getClosestOptionFrom(event.target);
     if (!option) return;
 
     this.setActive(option);
@@ -108,7 +104,7 @@ export default class Combobox {
     if (this.isMouseMoving) return;
 
     this.isMouseMoving = true;
-    const option = getClosestOptionFrom(event.target as HTMLElement);
+    const option = getClosestOptionFrom(event.target);
     if (!option) return;
 
     this.setActive(option);
@@ -196,7 +192,7 @@ function commit(list: HTMLElement) {
   return true;
 }
 
-function getClosestOptionFrom(target: HTMLElement) {
+function getClosestOptionFrom(target: HTMLElement | EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false;
 
   const option = target.closest<HTMLElement>('[role="option"]');

--- a/packages/auto-complete-element/src/combobox.ts
+++ b/packages/auto-complete-element/src/combobox.ts
@@ -5,14 +5,16 @@ const ctrlBindings = !!navigator.userAgent.match(/Macintosh/);
 export default class Combobox {
   input: HTMLInputElement;
   list: HTMLElement;
+  isMultiple: boolean;
   // Combobox does not use an actual hover/focus because it is not possible to focus input and options elements at the
   // same time. So for the options, it uses `data-tracking` to mimic mouse hover. But `data-tracking` is also activated
   // when ArrowDown and ArrowUp key is pressed. This distinction will help us know how the tracking is done.
   isMouseMoving = false;
 
-  constructor(input: HTMLInputElement, list: HTMLElement) {
+  constructor(input: HTMLInputElement, list: HTMLElement, { isMultiple = false } = {}) {
     this.input = input;
     this.list = list;
+    this.isMultiple = isMultiple;
 
     if (!this.list.id) this.list.id = brandedId();
 
@@ -22,6 +24,9 @@ export default class Combobox {
     this.input.setAttribute('aria-controls', this.list.id);
     this.input.setAttribute('aria-autocomplete', 'list');
     this.list.setAttribute('role', 'listbox');
+    if (this.isMultiple) {
+      this.list.setAttribute('aria-multiselectable', 'true');
+    }
 
     this.onKeydown = this.onKeydown.bind(this);
     this.onClick = this.onClick.bind(this);
@@ -129,8 +134,12 @@ export default class Combobox {
   }
 
   selectOption(option: HTMLElement) {
-    for (const el of this.options.filter(enabled)) {
-      el.setAttribute('aria-selected', (el === option).toString());
+    if (this.isMultiple) {
+      option.setAttribute('aria-selected', (option.getAttribute('aria-selected') !== 'true').toString());
+    } else {
+      for (const el of this.options.filter(enabled)) {
+        el.setAttribute('aria-selected', (el === option).toString());
+      }
     }
   }
 

--- a/packages/utils/src/delay.ts
+++ b/packages/utils/src/delay.ts
@@ -1,0 +1,12 @@
+export function debounce<T extends unknown[]>(callback: (...Rest: T) => unknown, wait = 0): (...Rest: T) => void {
+  let timeout: number;
+
+  return function (...Rest) {
+    clearTimeout(timeout);
+
+    timeout = window.setTimeout(() => {
+      clearTimeout(timeout);
+      callback(...Rest);
+    }, wait);
+  };
+}


### PR DESCRIPTION
## Multiple selections

You can set the `multiple` attribute on the `<auto-complete>` to allow selections on multiple options.

```html
<auto-complete for="list" multiple>
  <input type="text">
  <ul id="list">
    <li role="option">Option 1</li>
    <li role="option">Option 2</li>
    <li role="option">Option 3</li>
  </ul>
</auto-complete>
```