### PR TITLE
details-modal-element: release 0.2.0

### DIFF
--- a/packages/details-modal-element/CHANGELOG.md
+++ b/packages/details-modal-element/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.0] - 2022-06-12
 
 ### Added
-- `data-modal-close` attribute can be added to a clickable element inside the `<details>` to close the modal
+- `data-modal-close` attribute can be added to a clickable element inside the `<details>` to close the modal - [#14](https://github.com/abeidahmed/dahli/pull/14)
 
 ## [0.1.1] - 2022-05-30
 

--- a/packages/details-modal-element/README.md
+++ b/packages/details-modal-element/README.md
@@ -46,7 +46,7 @@ Modal can be closed using the `data-modal-close` attribute.
 <button type="button" data-modal-close>Close modal</button>
 ```
 
-Modal can be closed using the `method="dialog"` attribute on the `<form>`.
+Modal can also be closed using the `method="dialog"` attribute on the `<form>`.
 
 ```html
 <details>

--- a/packages/details-modal-element/package.json
+++ b/packages/details-modal-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dahli/details-modal-element",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A modal component that works with the <details> tag.",
   "homepage": "https://github.com/abeidahmed/dahli/tree/main/packages/details-modal-element#readme",
   "bugs": "https://github.com/abeidahmed/dahli/issues?q=is%3Aopen+is%3Aissue+label%3Adetails-modal",


### PR DESCRIPTION
### Added
- `data-modal-close` attribute can be added to a clickable element inside the `<details>` to close the modal - [#14](https://github.com/abeidahmed/dahli/pull/14)
